### PR TITLE
Add Invoke to ControlBase

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -41,6 +41,7 @@ type Controller interface {
 	Font() *Font
 	SetFont(font *Font)
 	InvokeRequired() bool
+	Invoke(func())
 	PreTranslateMessage(msg *w32.MSG) bool
 	WndProc(msg uint32, wparam, lparam uintptr) uintptr
 
@@ -77,4 +78,6 @@ type Controller interface {
 	//Paint events
 	OnPaint() *EventManager
 	OnSize() *EventManager
+
+	invokeCallbacks()
 }

--- a/utils.go
+++ b/utils.go
@@ -97,6 +97,16 @@ func RegisterClass(className string, wndproc uintptr) {
 	}
 }
 
+func RegisterWindowMessage(name string) uint32 {
+	n := syscall.StringToUTF16Ptr(name)
+
+	ret := w32.RegisterWindowMessage(n)
+	if ret == 0 {
+		panic(syscall.GetLastError())
+	}
+	return ret
+}
+
 func getMonitorInfo(hwnd w32.HWND) *w32.MONITORINFO {
 	currentMonitor := w32.MonitorFromWindow(hwnd, w32.MONITOR_DEFAULTTONEAREST)
 	var info w32.MONITORINFO

--- a/w32/user32.go
+++ b/w32/user32.go
@@ -65,6 +65,7 @@ var (
 	procMessageBox                    = moduser32.NewProc("MessageBoxW")
 	procGetSystemMetrics              = moduser32.NewProc("GetSystemMetrics")
 	procPostThreadMessageW            = moduser32.NewProc("PostThreadMessageW")
+	procRegisterWindowMessageA        = moduser32.NewProc("RegisterWindowMessageA")
 	//procSysColorBrush            = moduser32.NewProc("GetSysColorBrush")
 	procCopyRect          = moduser32.NewProc("CopyRect")
 	procEqualRect         = moduser32.NewProc("EqualRect")
@@ -209,6 +210,13 @@ func UpdateWindow(hwnd HWND) bool {
 
 func PostThreadMessage(threadID HANDLE, msg int, wp, lp uintptr) {
 	procPostThreadMessageW.Call(threadID, uintptr(msg), wp, lp)
+}
+
+func RegisterWindowMessage(name *uint16) uint32 {
+	ret, _, _ := procRegisterWindowMessageA.Call(
+		uintptr(unsafe.Pointer(name)))
+
+	return uint32(ret)
 }
 
 func PostMainThreadMessage(msg uint32, wp, lp uintptr) bool {

--- a/wndproc.go
+++ b/wndproc.go
@@ -11,6 +11,12 @@ import (
 	"github.com/leaanthony/winc/w32"
 )
 
+var wmInvokeCallback uint32
+
+func init() {
+	wmInvokeCallback = RegisterWindowMessage("WincV0.InvokeCallback")
+}
+
 func genPoint(p uintptr) (x, y int) {
 	x = int(w32.LOWORD(uint32(p)))
 	y = int(w32.HIWORD(uint32(p)))
@@ -136,7 +142,8 @@ func generalWndProc(hwnd w32.HWND, msg uint32, wparam, lparam uintptr) uintptr {
 		case w32.WM_SIZE:
 			x, y := genPoint(lparam)
 			controller.OnSize().Fire(NewEvent(controller, &SizeEventData{uint(wparam), x, y}))
-
+		case wmInvokeCallback:
+			controller.invokeCallbacks()
 		}
 		return ret
 	}


### PR DESCRIPTION
Invoke could be used to fix wailsapp/wails#969

The idea behind Invoke is like the .NET `Control.Invoke Method`, it executes a delegate on the thread that owns the window handle.