### PR TITLE
Add GetMonitorInfo function for Windows < 8.1 DPI fallback functionality

### DIFF
--- a/w32/user32.go
+++ b/w32/user32.go
@@ -125,6 +125,7 @@ var (
 	procMonitorFromRect               = moduser32.NewProc("MonitorFromRect")
 	procMonitorFromWindow             = moduser32.NewProc("MonitorFromWindow")
 	procGetMonitorInfo                = moduser32.NewProc("GetMonitorInfoW")
+	procGetDpiForSystem               = moduser32.NewProc("GetDpiForSystem")
 	procEnumDisplayMonitors           = moduser32.NewProc("EnumDisplayMonitors")
 	procEnumDisplaySettingsEx         = moduser32.NewProc("EnumDisplaySettingsExW")
 	procChangeDisplaySettingsEx       = moduser32.NewProc("ChangeDisplaySettingsExW")
@@ -1093,6 +1094,11 @@ func MonitorFromWindow(hwnd HWND, dwFlags uint32) HMONITOR {
 		uintptr(dwFlags),
 	)
 	return HMONITOR(ret)
+}
+
+func GetDpiForSystem() uint {
+	ret, _, _ := procGetDpiForSystem.Call()
+	return ret
 }
 
 func GetMonitorInfo(hMonitor HMONITOR, lmpi *MONITORINFO) bool {


### PR DESCRIPTION
 This is required to fix https://github.com/wailsapp/wails/issues/1063