### PR TITLE
Improve DPI handling by using the new HiDPI GetDpiForWindow method

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -142,3 +142,8 @@ func ScreenToClientRect(hwnd w32.HWND, rect *w32.RECT) *Rect {
 	r1, b1, _ := w32.ScreenToClient(hwnd, int(r), int(b))
 	return NewRect(l1, t1, r1, b1)
 }
+
+// ScaleWithDPI scales the pixels from the default DPI-Space (96) to the target DPI-Space.
+func ScaleWithDPI(pixels int, dpi uint) int {
+	return (pixels * int(dpi)) / 96
+}

--- a/w32/shcore.go
+++ b/w32/shcore.go
@@ -11,6 +11,11 @@ var (
 	procGetDpiForMonitor = modshcore.NewProc("GetDpiForMonitor")
 )
 
+func HasGetDPIForMonitorFunc() bool {
+	err := procGetDpiForMonitor.Find()
+	return err == nil
+}
+
 func GetDPIForMonitor(hmonitor HMONITOR, dpiType MONITOR_DPI_TYPE, dpiX *UINT, dpiY *UINT) uintptr {
 	ret, _, _ := procGetDpiForMonitor.Call(
 		hmonitor,

--- a/w32/user32.go
+++ b/w32/user32.go
@@ -126,6 +126,7 @@ var (
 	procMonitorFromWindow             = moduser32.NewProc("MonitorFromWindow")
 	procGetMonitorInfo                = moduser32.NewProc("GetMonitorInfoW")
 	procGetDpiForSystem               = moduser32.NewProc("GetDpiForSystem")
+	procGetDpiForWindow               = moduser32.NewProc("GetDpiForWindow")
 	procEnumDisplayMonitors           = moduser32.NewProc("EnumDisplayMonitors")
 	procEnumDisplaySettingsEx         = moduser32.NewProc("EnumDisplaySettingsExW")
 	procChangeDisplaySettingsEx       = moduser32.NewProc("ChangeDisplaySettingsExW")
@@ -267,6 +268,16 @@ func AdjustWindowRect(rect *RECT, style uint, menu bool) bool {
 func DestroyWindow(hwnd HWND) bool {
 	ret, _, _ := procDestroyWindow.Call(hwnd)
 	return ret != 0
+}
+
+func HasGetDpiForWindowFunc() bool {
+	err := procDestroyWindow.Find()
+	return err == nil
+}
+
+func GetDpiForWindow(hwnd HWND) UINT {
+	dpi, _, _ := procGetDpiForWindow.Call(hwnd)
+	return uint(dpi)
 }
 
 func SetWindowCompositionAttribute(hwnd HWND, data *WINDOWCOMPOSITIONATTRIBDATA) bool {


### PR DESCRIPTION
Use GetDpiForWindow function to determine the DPI of a window
available on Windows 10, 1607 and later

This new function is consistent with the WM_DPICHANGED event.
If the function is not available it will fallback to GetDPIForMonitor
of the monitor with the largest intersection.
If that function is not available, it will fallback to the SystemDPI.